### PR TITLE
Syntax update for Windows usage

### DIFF
--- a/git.m
+++ b/git.m
@@ -67,11 +67,11 @@ function git(varargin)
         % Otherwise we can call the real git with the arguments
         arguments = parse(varargin{:});  
         if ispc
-          prog = 'type'
+          prog = '';
         else
-          prog = 'cat'
+          prog = ' | cat';
         end
-        [~,result] = system(['git ',arguments,' | ',prog]);
+        [~,result] = system(['git ',arguments,prog]);
         disp(result)
     end
 end


### PR DESCRIPTION
Updated the syntax for use on windows systems. The ' | type' was causing
an error on the windows system call. Basic testing shows that removing
the ' | type' from the system call results in a working script.

I am not familiar with the purpose of the ' | cat' part of the function on Mac OS X machines. If the purpose of that can be explained, I might be able to replicate that on the PC side. Otherwise, this update does work on Windows systems now. I am unable to test on OS X, but tried to ensure not to 'break' anything for other users.
