### PR TITLE
More lightweight check for git and pagination for output

### DIFF
--- a/git.m
+++ b/git.m
@@ -71,7 +71,14 @@ function git(varargin)
           prog = ' | cat';
         end
         [~,result] = system(['git ',arguments,prog]);
+
+        % save current status of pagination, then turn it on
+        morestatus=get(0,'More');
+        more('on')
+        % show result
         disp(result)
+        % revert pagination to previous status
+        more(morestatus)
     end
 end
 


### PR DESCRIPTION
Hey.

Got two small suggestions for your git-wrapper:
- The first commit uses "git --version" to check for existence of git instead of "git status" which is a lot faster in some situations
- The second commit turns on pagination for displaying the output of git (and then turns it off if it wasn't on before). This more closely mimics the defaults of git on the commandline.

Thanks for your effort!
