### PR TITLE
Suppressed printing of ans before git command output

### DIFF
--- a/git.m
+++ b/git.m
@@ -1,4 +1,4 @@
-function result = git(varargin)
+function git(varargin)
 % A thin MATLAB wrapper for Git.
 % 
 %   Short instructions:
@@ -52,15 +52,23 @@ function result = git(varargin)
 % v0.4,     20 November 2013-- TN: Searching for git in default directories,
 %                               returning results as variable
 % 
+% v0.5,     22 January 2015 -- TP: Suppressed printing of ans before
+%                                  git command output
+% 
 % Contributors: (MR) Manu Raghavan
 %               (TH) Timothy Hansell
 %               (TN) Tassos Natsakis
+%               (TP) Tyler Parsons
+%
 
 
-% Test to see if git is installed
-[status,~] = system('git --version');
-% if git is in the path this will return a status of 0
-% it will return a 1 only if the command is not found
+    % Test to see if git is installed
+    [status,~] = system('git --version');
+    % if git is in the path this will return a status of 0
+    % it will return a 1 only if the command is not found
+
+    % git command output
+    result = '';
 
     if status
         % Checking if git exists in the default installation folders (for
@@ -96,6 +104,11 @@ function result = git(varargin)
 		end
         [~,result] = system(['git ',arguments,prog]);
     end
+    
+    % Display result instead of returning it
+    % to suppress output of ans
+    disp(result);
+    
 end
 
 function space_delimited_list = parse(varargin)


### PR DESCRIPTION
I'm using MATLAB-git for easy access to git from my command window and it has worked wonderfully. I wanted my git integration to be more reminiscent of a unix command line experience, and so I added a feature to suppress the ans output.  The result is that this

![gitans](https://cloud.githubusercontent.com/assets/7098092/5866194/1754906e-a25d-11e4-923d-f6bc3fb3cebb.PNG)

becomes this

![gitnoans](https://cloud.githubusercontent.com/assets/7098092/5866195/1755535a-a25d-11e4-8d65-12e04ff5129a.PNG) .


The change reduces the amount of text one needs to scroll through and is aesthetically cleaner.  It has improved my experience with MATLAB-git, and I would like to share my changes.
